### PR TITLE
Using utf8 broke vim with utf8 already present.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,6 @@
 root = true
 
 [*.{md,xml,org}]
-charset = utf-8
+# charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
at least, I think that is what happens.
shrug.
